### PR TITLE
Fixed ConnectionState never switching to Connected when application is not using async

### DIFF
--- a/OBSClient/ObsClient.cs
+++ b/OBSClient/ObsClient.cs
@@ -588,8 +588,8 @@
                 throw new ObsClientException($"Unexpected response type {responseMessage.Data?.GetType().Name} in {MethodBase.GetCurrentMethod()?.Name}");
             }
 
-            if (this._authenticationComplete.Task.Status != TaskStatus.RanToCompletion) this._authenticationComplete.SetResult(true);
             this.ConnectionState = ConnectionState.Connected;
+            if (this._authenticationComplete.Task.Status != TaskStatus.RanToCompletion) this._authenticationComplete.SetResult(true);
         }
 
         private void ProcessRequestResponseMessage(ObsMessage responseMessage)


### PR DESCRIPTION
When `this._authenticationComplete.SetResult(true)` is run inside `ProcessIdentifiedMessage()`, the `ConnectAsync()` method immediately returns.
If the calling application is not using async but instead blocking, the line below is never executed and the state is never changed to `Connected`.